### PR TITLE
Cスタイルキャストをstatic_castに変更

### DIFF
--- a/data-structure/cumulativesum.cpp
+++ b/data-structure/cumulativesum.cpp
@@ -10,7 +10,7 @@ struct cumulative_sum {
   void set(int k, T x) { dat[k + 1] = x; }
 
   void build() {
-    for ( int i = 0; i < (int)dat.size() - 1; i++ ) {
+    for ( int i = 0; i < static_cast<int>(dat.size()) - 1; i++ ) {
       dat[i + 1] += dat[i];
     }
   }

--- a/data-structure/cumulativesum2d.cpp
+++ b/data-structure/cumulativesum2d.cpp
@@ -11,8 +11,8 @@ struct cumulative_sum_2d {
   void set(int y, int x, T v) { data[y + 1][x + 1] = v; }
 
   void build() {
-    for ( int i = 1; i < (int)data.size(); i++ ) {
-      for ( int j = 1; j < (int)data[i].size(); j++ ) {
+    for ( int i = 1; i < static_cast<int>(data.size()); i++ ) {
+      for ( int j = 1; j < static_cast<int>(data[i].size()); j++ ) {
         data[i][j] += data[i][j - 1] + data[i - 1][j] - data[i - 1][j - 1];
       }
     }

--- a/data-structure/dynamic_imos.cpp
+++ b/data-structure/dynamic_imos.cpp
@@ -28,7 +28,7 @@ struct dynamic_imos {
       imos[r] -= v;
     }
 
-    for ( int i = 1; i < (int)imos.size(); i++ ) {
+    for ( int i = 1; i < static_cast<int>(imos.size()); i++ ) {
       imos[i] += imos[i - 1];
     }
   }
@@ -36,7 +36,7 @@ struct dynamic_imos {
   // vector<[l,r), value>
   vector<pair<pair<T, T>, T>> section_values() {
     vector<pair<pair<T, T>, T>> res(xs.size() - 1);
-    for ( int i = 0; i < (int)xs.size() - 1; i++ ) {
+    for ( int i = 0; i < static_cast<int>(xs.size()) - 1; i++ ) {
       T l = xs[i];
       T r = xs[i + 1];
       T v = imos[i];

--- a/dp/rerootingdp.cpp
+++ b/dp/rerootingdp.cpp
@@ -31,7 +31,7 @@ private:
       int par = pars[v];
       int par_idx = -1;
       T accum = identity;
-      for (int j = 0; j < (int)g[v].size(); j++) {
+      for (int j = 0; j < static_cast<int>(g[v].size()); j++) {
         int to = g[v][j].first;
         if (to == par) {
           par_idx = j;
@@ -80,7 +80,7 @@ public:
     order.assign(g.size(), -1);
     results.assign(g.size(), identity);
     ch_tree.resize(g.size());
-    for (int i = 0; i < (int)g.size(); i++) {
+    for (int i = 0; i < static_cast<int>(g.size()); i++) {
       ch_tree[i].assign(g[i].size(), identity);
     }
     int idx = 0;

--- a/graph/stronglyconnectedcomponent.cpp
+++ b/graph/stronglyconnectedcomponent.cpp
@@ -67,7 +67,7 @@ public:
   vector<vector<int>> topological_sort() {
     vector<vector<int>> graph(cnt);
     vector<int> in_degree(cnt);
-    for ( int i = 0; i < (int)edges.size(); i++ ) {
+    for ( int i = 0; i < static_cast<int>(edges.size()); i++ ) {
       auto [from, to] = edges[i];
       if ( same(from, to) ) continue;
       graph[groups[from]].emplace_back(groups[to]);

--- a/graph/tree.cpp
+++ b/graph/tree.cpp
@@ -8,7 +8,7 @@ void debug_function(string_view name, const T &a, T2 &&...rest) {
   stack<char> bs;
   string_view lbs = "({[<", rbs = ")}]>";
   int end = name.size();
-  for ( int i = 0; i < (int)name.size(); i++ ) {
+  for ( int i = 0; i < static_cast<int>(name.size()); i++ ) {
     if ( lbs.find(name[i]) != string::npos ) bs.push(name[i]);
     if ( rbs.find(name[i]) != string::npos && !bs.empty() ) bs.pop();
     if ( name[i] == ',' && bs.empty() ) {
@@ -109,10 +109,10 @@ private:
 
     void build(const vector<pair<int, int>> &v) {
       int b = 0;
-      while ( (1 << b) <= (int)v.size() )
+      while ( (1 << b) <= static_cast<int>(v.size()) )
         ++b;
       st.assign(b, vector<pair<int, int>>(1 << b));
-      for ( int i = 0; i < (int)v.size(); i++ ) {
+      for ( int i = 0; i < static_cast<int>(v.size()); i++ ) {
         st[0][i] = v[i];
       }
       for ( int i = 1; i < b; i++ ) {
@@ -121,7 +121,7 @@ private:
         }
       }
       lookup.resize(v.size() + 1);
-      for ( int i = 2; i < (int)lookup.size(); i++ ) {
+      for ( int i = 2; i < static_cast<int>(lookup.size()); i++ ) {
         lookup[i] = lookup[i >> 1] + 1;
       }
     }
@@ -275,7 +275,7 @@ public:
 
     // build sparse table
     vector<pair<int, int>> dep_idx(dep.size());
-    for ( int i = 0; i < (int)dep.size(); i++ ) {
+    for ( int i = 0; i < static_cast<int>(dep.size()); i++ ) {
       auto &[depth, idx] = dep_idx[i];
       depth = dep[i];
       idx = i;

--- a/math/divisor.cpp
+++ b/math/divisor.cpp
@@ -18,7 +18,7 @@ int main() {
   long long n;
   cin >> n;
   vector<long long> v = divisor(n);
-  for ( int i = 0; i < (int)v.size(); i++ ) {
+  for ( int i = 0; i < static_cast<int>(v.size()); i++ ) {
     if ( i ) cout << ' ';
     cout << v[i];
   }

--- a/math/eratosthenes_sieve.cpp
+++ b/math/eratosthenes_sieve.cpp
@@ -28,7 +28,7 @@ int main(){
   eratosthenes_sieve sieve(n);
   sieve.build();
 
-  for(int i=0;i<(int)sieve.prime_table.size();i++){
+  for(int i=0;i<static_cast<int>(sieve.prime_table.size());i++){
     if(sieve.prime_table[i]){
       cout<<i<<' ';
     }

--- a/string/join.cpp
+++ b/string/join.cpp
@@ -3,7 +3,7 @@ using namespace std;
 
 string join(const vector<string> &strs, const string &sep) {
   string res = "";
-  for ( int i = 0; i < (int)strs.size(); i++ ) {
+  for ( int i = 0; i < static_cast<int>(strs.size()); i++ ) {
     if ( i ) res += sep;
     res += strs[i];
   }

--- a/string/rollinghash2d.cpp
+++ b/string/rollinghash2d.cpp
@@ -13,8 +13,8 @@ struct rolling_hash_2d {
     void set(int y, int x, ll v) { data[y + 1][x + 1] = v; }
 
     void build(ll mod) {
-      for ( int i = 1; i < (int)data.size(); i++ ) {
-        for ( int j = 1; j < (int)data[i].size(); j++ ) {
+      for ( int i = 1; i < static_cast<int>(data.size()); i++ ) {
+        for ( int j = 1; j < static_cast<int>(data[i].size()); j++ ) {
           data[i][j] += (data[i][j - 1] + data[i - 1][j] - data[i - 1][j - 1]) % mod;
           if ( data[i][j] < 0 ) data[i][j] += mod;
         }
@@ -39,7 +39,7 @@ struct rolling_hash_2d {
     set_base(B1, B2);
     set_mod(MOD);
     dat.resize(s.size());
-    for ( int i = 0; i < (int)s.size(); i++ ) {
+    for ( int i = 0; i < static_cast<int>(s.size()); i++ ) {
       for ( char c : s[i] ) {
         dat[i].emplace_back(c);
       }

--- a/tools/rotate_2d.cpp
+++ b/tools/rotate_2d.cpp
@@ -33,12 +33,12 @@ int main() {
     cin >> s[i];
 
   vector<string> s2 = rotate_cw(s);
-  for (int i = 0; i < (int)s2.size(); i++) {
+  for (int i = 0; i < static_cast<int>(s2.size()); i++) {
     cout << s2[i] << endl;
   }
 
   s2 = rotate_ccw(s);
-  for (int i = 0; i < (int)s2.size(); i++) {
+  for (int i = 0; i < static_cast<int>(s2.size()); i++) {
     cout << s2[i] << endl;
   }
 }

--- a/tools/sliced.cpp
+++ b/tools/sliced.cpp
@@ -40,7 +40,7 @@ struct Sliced {
 } sliced;
 
 void output(vector<int> v){
-  for ( int i = 0; i < (int)v.size(); i++ ) {
+  for ( int i = 0; i < static_cast<int>(v.size()); i++ ) {
     if ( i ) cout << ' ';
     cout << v[i];
   }

--- a/tools/vectortostring.cpp
+++ b/tools/vectortostring.cpp
@@ -4,7 +4,7 @@ using namespace std;
 template <typename T>
 string vector_to_string(const vector<T> &vs, const string &sep = " ") {
   stringstream ss;
-  for ( int i = 0; i < (int)vs.size(); i++ ) {
+  for ( int i = 0; i < static_cast<int>(vs.size()); i++ ) {
     if ( i ) ss << sep;
     ss << vs[i];
   }


### PR DESCRIPTION
## Issue 番号
<!-- この Pull request に関連する Issue 番号 -->
<!-- example: - close #10 -->
- close #11 

## 変更内容
<!-- この Pull request の変更点 -->
`(int)hoge.size()` を `static_cast<int>(hoge.size()` に変更した

`grep -e '(int)' -rl * | grep -v library | sort | xargs sed -i -E -e "s/\(int\)(.*)\.size\(\)/static_cast<int>(\1.size())/g"`

上の正規表現でやっただけなので、`.size()` 以外のものがあったら対応しきれていない