### PR TITLE
`math/mod-factorial.hpp` の設計見直し

### DIFF
--- a/math/mod-factorial.hpp
+++ b/math/mod-factorial.hpp
@@ -7,25 +7,51 @@
 
 namespace math {
   using mint = atcoder::modint1000000007;
+  template <typename ModInt = mint>
   class ModFactorial {
-    vector<mint> fact, invfact;
-
-  public:
-    ModFactorial(int N): fact(N + 1), invfact(N + 1) {
-      fact[0] = 1;
-      for (int i = 1; i <= N; i++)
-        fact[i] = fact[i - 1] * i;
-      invfact[N] = 1 / fact[N];
-      for (int i = N - 1; i >= 0; i--)
-        invfact[i] = invfact[i + 1] * (i + 1);
+    vector<ModInt> fact, invfact;
+    int min_pow2_greater_equal_than(int k){
+      int pow2 = 1;
+      while (pow2 < k) {
+        pow2 <<= 1;
+      }
+      return pow2;
     }
 
-    mint factorial(int k) { return fact[k]; }
-    mint inv_factorial(int k) { return invfact[k]; }
-    mint inv(int k) { return mint(k).inv(); }
+  public:
+    ModFactorial() = default;
 
-    mint permutation(int n, int k) { return fact[n] * invfact[n - k]; }
-    mint combination(int n, int k) { return fact[n] * invfact[k] * invfact[n - k]; }
-    mint homogeneous(int n, int k) { return combination(n + k - 1, k); }
+    ModInt factorial(int k) {
+      if (k < static_cast<int>(fact.size())) return fact[k];
+
+      int pow2 = min_pow2_greater_equal_than(k);
+      int old_size = fact.size();
+      fact.resize(pow2 + 1);
+
+      for (int i = old_size; i < pow2; i++) {
+        fact[i + 1] *= fact[i] * ModInt(i + 1);
+      }
+      return fact[k];
+    }
+
+    ModInt inv_factorial(int k) {
+      if (k < static_cast<int>(invfact.size())) return invfact[k];
+
+      int pow2 = min_pow2_greater_equal_than(k);
+      int old_size = fact.size();
+      invfact.resize(pow2 + 1);
+
+      invfact[pow2] = ModInt(1) / ModInt(pow2);
+      for(int i = pow2; i > old_size; i--){
+        invfact[i - 1] = invfact[i] * ModInt(i);
+      }
+      return invfact[k];
+    }
+
+    ModInt inv(int k) { return ModInt(1) / ModInt(k); }
+
+    ModInt permutation(int n, int k) { return factorial(n) * inv_factorial(n - k); }
+    ModInt combination(int n, int k) { return factorial(n) * inv_factorial(k) * inv_factorial(n - k); }
+    ModInt homogeneous(int n, int k) { return combination(n + k - 1, k); }
   };
 } // namespace math


### PR DESCRIPTION
## Issue 番号
<!-- この Pull request に関連する Issue 番号 -->
<!-- example: - close #10 -->
- close #67 

## 変更内容
<!-- この Pull request の変更点 -->
階乗を求める計算を前計算なしにして、クエリごとに動的に求めるようにした

具体的には`std::vector`の`push_back`と同じ要領でならしO(1)で答える