### PR TITLE
reversed.hpp の追加

### DIFF
--- a/tools/container-traits.hpp
+++ b/tools/container-traits.hpp
@@ -52,10 +52,10 @@ namespace tools {
   using IsMap = traits_helper::IsTemplate<map, T>;
 
   template <typename T>
-  using IsMultiset = traits_helper::IsTemplate<multiset, T>;
+  using IsMultiSet = traits_helper::IsTemplate<multiset, T>;
 
   template <typename T>
-  using IsMultimap = traits_helper::IsTemplate<multimap, T>;
+  using IsMultiMap = traits_helper::IsTemplate<multimap, T>;
 
   // Unordered associative containers
   template <typename T>

--- a/tools/reversed.hpp
+++ b/tools/reversed.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "./base.hpp"
+
+#include <type_traits>
+#include <algorithm>
+
+namespace tools {
+  template <typename Container>
+  auto reversed(Container c){
+    reverse(c.begin(), c.end());
+    return c;
+  }
+}

--- a/tools/reversed.hpp
+++ b/tools/reversed.hpp
@@ -1,14 +1,65 @@
 #pragma once
 
 #include "./base.hpp"
+#include "./container-traits.hpp"
 
-#include <type_traits>
 #include <algorithm>
+#include <type_traits>
 
 namespace tools {
+  // array or vector or deque or string
   template <typename Container>
-  auto reversed(Container c){
-    reverse(c.begin(), c.end());
-    return c;
+  constexpr Container reversed(const Container &c) {
+    Container res = c;
+    reverse(res.begin(), res.end());
+    return res;
   }
-}
+
+  // list or forward_list
+  template <template <typename T> typename Container, typename T, enable_if_t<(is_forward_list_v<Container<T>> or is_list_v<Container<T>>)> * = nullptr>
+  constexpr auto reversed(const Container<T> &ls) {
+    Container<T> res = ls;
+    res.reverse();
+    return res;
+  }
+
+  // set or multiset
+  template <template <typename T, typename Compare> typename Container, typename T, typename Compare, enable_if_t<(is_set_v<Container<T, Compare>> or is_multiset_v<Container<T, Compare>>)> * = nullptr>
+  constexpr auto reversed(const Container<T, Compare> &st) {
+    if constexpr (is_same_v<Compare, less<T>>) {
+      Container<T, greater<T>> res;
+      for (const auto &v: st) {
+        res.emplace_hint(res.begin(), v);
+      }
+      return res;
+    } else {
+      Container<T, less<T>> res;
+      for (const auto &v: st) {
+        res.emplace_hint(res.begin(), v);
+      }
+      return res;
+    }
+  }
+
+  // map or multimap
+  template <template <typename T1, typename T2, typename Compare> typename Container,
+            typename T1,
+            typename T2,
+            typename Compare,
+            enable_if_t<(is_map_v<Container<T1, T2, Compare>> or is_multimap_v<Container<T1, T2, Compare>>)> * = nullptr>
+  constexpr auto reversed(const Container<T1, T2, Compare> &mp) {
+    if constexpr (is_same_v<Compare, less<T1>>) {
+      Container<T1, T2, greater<T1>> res;
+      for (const auto &p: mp) {
+        res.emplace_hint(res.begin(), p);
+      }
+      return res;
+    } else {
+      Container<T1, T2, less<T1>> res;
+      for (const auto &p: mp) {
+        res.emplace_hint(res.begin(), p);
+      }
+      return res;
+    }
+  }
+} // namespace tools


### PR DESCRIPTION
## Issue 番号
<!-- この Pull request に関連する Issue 番号 -->
<!-- example: - close #10 -->
- close #90 

## 変更内容
<!-- この Pull request の変更点 -->
コンテナに対して reverse 操作を行ったコンテナを返す
具体的には下記

- array, vector, deque, string
  std::reverse を行ったものを返す
- list, forward_list
  Container.reverse() を行ったものを返す
- set, multiset, map, multimap
  Container::key_compare が less<T> のときは greater<T>  
  それ以外は less<T> にして返す